### PR TITLE
Week4 mbti 테스트 진행정보 저장.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,7 +48,7 @@ android {
         applicationId "com.example.mbti"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 19
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/lib/config/providers.dart
+++ b/lib/config/providers.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/foundation.dart';
 import 'package:mbti/features/auth/auth_provider.dart';
+import 'package:mbti/features/user/user_question_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 import 'package:flutter_web_plugins/url_strategy.dart';
@@ -46,4 +47,7 @@ Future<void> initializeProviders(ProviderContainer container) async {
 
   /// Auth
   container.read(authControllerProvider);
+
+  /// User
+  container.read(userQuestionUpdateControllerProvider);
 }

--- a/lib/features/mbti/infrastructure/repositories/question_repository.dart
+++ b/lib/features/mbti/infrastructure/repositories/question_repository.dart
@@ -19,7 +19,7 @@ class QuestionRepository implements QuestionRepositoryInterface {
     try {
       final data = await client
           .from(_table)
-          .select('*')
+          .select()
           .withConverter(QuestionEntityConverter.toList);
       log('QuestionRepository getQuestions : ${data.toString()}');
       return right(data);

--- a/lib/features/mbti/mbti_provider.dart
+++ b/lib/features/mbti/mbti_provider.dart
@@ -18,3 +18,5 @@ final questionRepositoryProvider = Provider<QuestionRepositoryInterface>(
 final questionsListControllerProvider = StateNotifierProvider<
         QuestionsListController, AsyncValue<List<QuestionEntity>>>(
     (ref) => QuestionsListController(ref.watch(questionRepositoryProvider)));
+
+

--- a/lib/features/mbti/presentation/screens/qustions_screen.dart
+++ b/lib/features/mbti/presentation/screens/qustions_screen.dart
@@ -3,40 +3,45 @@ import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mbti/features/common/presentation/widgets/app_error.dart';
+import 'package:mbti/features/mbti/domain/entities/question_entity.dart';
 import 'package:mbti/features/mbti/mbti_provider.dart';
 import 'package:mbti/features/mbti/presentation/widgets/question_wdiget.dart';
+import 'package:mbti/features/user/user_question_provider.dart';
 
 class QuestionsScreen extends ConsumerWidget {
   QuestionsScreen({super.key});
 
-  final pageIndexProvider = StateProvider<int>((ref) => 1);
+  final _pageIndexProvider = StateProvider<int>((ref) => 1);
 
-  final PageController pageController = PageController(initialPage: 0);
+  PageController _pageController = PageController(initialPage: 0);
+
+  bool _initialized = false;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final questions = ref.watch(questionsListControllerProvider);
+    log('QuestionsScreen build');
     return Scaffold(
       appBar: AppBar(),
       body: questions.when(
         data: (questions) {
-          log(questions.toString());
+          _initialize(ref, questions);
           return Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               const SizedBox(
                 height: 100,
               ),
-              Text('${ref.watch(pageIndexProvider)}/${questions.length}'),
+              Text('${ref.watch(_pageIndexProvider)}/${questions.length}'),
               Expanded(
                 child: PageView.builder(
-                  controller: pageController,
+                  controller: _pageController,
                   itemCount: questions.length,
                   itemBuilder: (context, index) {
                     return QuestionCard(questionEntity: questions[index], next);
                   },
                   onPageChanged: (value) {
-                    ref.read(pageIndexProvider.notifier).state = value + 1;
+                    ref.read(_pageIndexProvider.notifier).state = value + 1;
                   },
                 ),
               ),
@@ -51,15 +56,44 @@ class QuestionsScreen extends ConsumerWidget {
     );
   }
 
-  next(String? type, int? score) {
+  _initialize(WidgetRef ref, List<QuestionEntity> questions) async {
+    log('_initialize : $_initialized');
+    if (_initialized) return;
+    _initialized = true;
+    final user = ref.read(userQuestionUpdateControllerProvider);
+    user.when(
+      data: (data) {
+        String? lastQuestionId = data.currentQuestionId;
+        log('lastQuestionId: $lastQuestionId');
+        if (lastQuestionId.isNotEmpty) {
+          var position =
+          questions.indexWhere((element) => element.id == lastQuestionId);
+          log('position: $position');
+          _pageController = PageController(initialPage: position + 1);
+          /// 위젯이 생성되는 동안 provider.read 는 허락되지 않는다...
+          /// 1. 프로바이더 수정을 위젯 라이프 사이클 외부로 이동.
+          /// 2. Delay...
+          /// 추천은 1번이지만... 외부로 변경할수 없어서.. 2번으로
+          Future.delayed(const Duration(microseconds: 300), () {
+            ref.read(_pageIndexProvider.notifier).state = position + 2;
+          });
+        }
+      },
+      error: (o, e) {},
+      loading: () {},
+    );
+  }
+
+  next(WidgetRef ref, QuestionEntity questionEntity, int? score) {
     final int nextPage;
-    if (pageController.page != null) {
-      nextPage = pageController.page!.toInt() + 1;
+    if (_pageController.page != null) {
+      nextPage = _pageController.page!.toInt() + 1;
     } else {
       nextPage = 0;
     }
-    pageController.jumpToPage(nextPage);
-    //todo save
+    ref
+        .read(userQuestionUpdateControllerProvider.notifier)
+        .update(questionEntity.id);
+    _pageController.jumpToPage(nextPage);
   }
-
 }

--- a/lib/features/mbti/presentation/widgets/question_wdiget.dart
+++ b/lib/features/mbti/presentation/widgets/question_wdiget.dart
@@ -7,7 +7,7 @@ class QuestionCard extends ConsumerWidget {
       : super(key: key);
 
   final QuestionEntity questionEntity;
-  final Function(String? type, int? score) next;
+  final Function(WidgetRef ref, QuestionEntity questionEntity, int? score) next;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -40,7 +40,7 @@ class QuestionCard extends ConsumerWidget {
                 children: [
                   Expanded(
                     child: ElevatedButton(
-                      onPressed: () => next(questionEntity.type, 40),
+                      onPressed: () => next(ref, questionEntity, 40),
                       style: ElevatedButton.styleFrom(
                           fixedSize: const Size(150, 150),
                           shape: const CircleBorder(),
@@ -50,7 +50,7 @@ class QuestionCard extends ConsumerWidget {
                   ),
                   Expanded(
                     child: ElevatedButton(
-                      onPressed: () => next(questionEntity.type, 20),
+                      onPressed: () => next(ref, questionEntity, 20),
                       style: ElevatedButton.styleFrom(
                         fixedSize: const Size(125, 125),
                         shape: const CircleBorder(),
@@ -61,7 +61,7 @@ class QuestionCard extends ConsumerWidget {
                   ),
                   Expanded(
                     child: ElevatedButton(
-                      onPressed: () => next(null, null),
+                      onPressed: () => next(ref, questionEntity, null),
                       style: ElevatedButton.styleFrom(
                         fixedSize: const Size(100, 100),
                         shape: const CircleBorder(),
@@ -72,7 +72,7 @@ class QuestionCard extends ConsumerWidget {
                   ),
                   Expanded(
                     child: ElevatedButton(
-                      onPressed: () => next(questionEntity.type, 20),
+                      onPressed: () => next(ref, questionEntity, 20),
                       style: ElevatedButton.styleFrom(
                         fixedSize: const Size(125, 125),
                         shape: const CircleBorder(),
@@ -83,7 +83,7 @@ class QuestionCard extends ConsumerWidget {
                   ),
                   Expanded(
                     child: ElevatedButton(
-                      onPressed: () => next(questionEntity.type, 40),
+                      onPressed: () => next(ref, questionEntity, 40),
                       style: ElevatedButton.styleFrom(
                           fixedSize: const Size(150, 150),
                           shape: const CircleBorder(),

--- a/lib/features/user/application/user_question_update_constroller.dart
+++ b/lib/features/user/application/user_question_update_constroller.dart
@@ -1,0 +1,23 @@
+
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mbti/features/user/domain/entities/user_question_entity.dart';
+import 'package:mbti/features/user/domain/repositories/user_repository_interface.dart';
+
+class UserQuestionUpdateController extends StateNotifier<AsyncValue<UserQuestionEntity>> {
+  UserQuestionUpdateController(this._repository): super(const AsyncValue.loading()) {
+    _get();
+  }
+
+  final UserQuestionRepositoryInterface _repository;
+
+  Future<void> _get() async {
+    final res = await _repository.getUserQuestion();
+    state = res.fold((l) => AsyncValue.error(l.toString(), StackTrace.current), AsyncValue.data);
+  }
+
+  Future<void> update(String questionId) async {
+    final res = await _repository.createOrUpdateUserQuestion(questionId);
+    state = res.fold((l) => AsyncValue.error(l.toString(), StackTrace.current), AsyncValue.data);
+  }
+}

--- a/lib/features/user/domain/entities/user_question_entity.dart
+++ b/lib/features/user/domain/entities/user_question_entity.dart
@@ -1,0 +1,15 @@
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'user_question_entity.freezed.dart';
+part 'user_question_entity.g.dart';
+
+@freezed
+class UserQuestionEntity with _$UserQuestionEntity {
+  const factory UserQuestionEntity({
+    required String currentQuestionId,
+    required String result,
+  }) = _UserQuestionEntity;
+
+  factory UserQuestionEntity.fromJson(Map<String, dynamic> json) =>
+      _$UserQuestionEntityFromJson(json);
+}

--- a/lib/features/user/domain/entities/user_question_entity.freezed.dart
+++ b/lib/features/user/domain/entities/user_question_entity.freezed.dart
@@ -1,0 +1,172 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user_question_entity.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+UserQuestionEntity _$UserQuestionEntityFromJson(Map<String, dynamic> json) {
+  return _UserQuestionEntity.fromJson(json);
+}
+
+/// @nodoc
+mixin _$UserQuestionEntity {
+  String get currentQuestionId => throw _privateConstructorUsedError;
+  String get result => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $UserQuestionEntityCopyWith<UserQuestionEntity> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $UserQuestionEntityCopyWith<$Res> {
+  factory $UserQuestionEntityCopyWith(
+          UserQuestionEntity value, $Res Function(UserQuestionEntity) then) =
+      _$UserQuestionEntityCopyWithImpl<$Res, UserQuestionEntity>;
+  @useResult
+  $Res call({String currentQuestionId, String result});
+}
+
+/// @nodoc
+class _$UserQuestionEntityCopyWithImpl<$Res, $Val extends UserQuestionEntity>
+    implements $UserQuestionEntityCopyWith<$Res> {
+  _$UserQuestionEntityCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? currentQuestionId = null,
+    Object? result = null,
+  }) {
+    return _then(_value.copyWith(
+      currentQuestionId: null == currentQuestionId
+          ? _value.currentQuestionId
+          : currentQuestionId // ignore: cast_nullable_to_non_nullable
+              as String,
+      result: null == result
+          ? _value.result
+          : result // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_UserQuestionEntityCopyWith<$Res>
+    implements $UserQuestionEntityCopyWith<$Res> {
+  factory _$$_UserQuestionEntityCopyWith(_$_UserQuestionEntity value,
+          $Res Function(_$_UserQuestionEntity) then) =
+      __$$_UserQuestionEntityCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String currentQuestionId, String result});
+}
+
+/// @nodoc
+class __$$_UserQuestionEntityCopyWithImpl<$Res>
+    extends _$UserQuestionEntityCopyWithImpl<$Res, _$_UserQuestionEntity>
+    implements _$$_UserQuestionEntityCopyWith<$Res> {
+  __$$_UserQuestionEntityCopyWithImpl(
+      _$_UserQuestionEntity _value, $Res Function(_$_UserQuestionEntity) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? currentQuestionId = null,
+    Object? result = null,
+  }) {
+    return _then(_$_UserQuestionEntity(
+      currentQuestionId: null == currentQuestionId
+          ? _value.currentQuestionId
+          : currentQuestionId // ignore: cast_nullable_to_non_nullable
+              as String,
+      result: null == result
+          ? _value.result
+          : result // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_UserQuestionEntity implements _UserQuestionEntity {
+  const _$_UserQuestionEntity(
+      {required this.currentQuestionId, required this.result});
+
+  factory _$_UserQuestionEntity.fromJson(Map<String, dynamic> json) =>
+      _$$_UserQuestionEntityFromJson(json);
+
+  @override
+  final String currentQuestionId;
+  @override
+  final String result;
+
+  @override
+  String toString() {
+    return 'UserQuestionEntity(currentQuestionId: $currentQuestionId, result: $result)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_UserQuestionEntity &&
+            (identical(other.currentQuestionId, currentQuestionId) ||
+                other.currentQuestionId == currentQuestionId) &&
+            (identical(other.result, result) || other.result == result));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, currentQuestionId, result);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_UserQuestionEntityCopyWith<_$_UserQuestionEntity> get copyWith =>
+      __$$_UserQuestionEntityCopyWithImpl<_$_UserQuestionEntity>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_UserQuestionEntityToJson(
+      this,
+    );
+  }
+}
+
+abstract class _UserQuestionEntity implements UserQuestionEntity {
+  const factory _UserQuestionEntity(
+      {required final String currentQuestionId,
+      required final String result}) = _$_UserQuestionEntity;
+
+  factory _UserQuestionEntity.fromJson(Map<String, dynamic> json) =
+      _$_UserQuestionEntity.fromJson;
+
+  @override
+  String get currentQuestionId;
+  @override
+  String get result;
+  @override
+  @JsonKey(ignore: true)
+  _$$_UserQuestionEntityCopyWith<_$_UserQuestionEntity> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/user/domain/entities/user_question_entity.g.dart
+++ b/lib/features/user/domain/entities/user_question_entity.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_question_entity.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_UserQuestionEntity _$$_UserQuestionEntityFromJson(
+        Map<String, dynamic> json) =>
+    _$_UserQuestionEntity(
+      currentQuestionId: json['currentQuestionId'] as String,
+      result: json['result'] as String,
+    );
+
+Map<String, dynamic> _$$_UserQuestionEntityToJson(
+        _$_UserQuestionEntity instance) =>
+    <String, dynamic>{
+      'currentQuestionId': instance.currentQuestionId,
+      'result': instance.result,
+    };

--- a/lib/features/user/domain/entities/user_question_entity_converter.dart
+++ b/lib/features/user/domain/entities/user_question_entity_converter.dart
@@ -1,0 +1,11 @@
+
+
+import 'package:mbti/features/user/domain/entities/user_question_entity.dart';
+
+class UserQuestionEntityConverter {
+  static UserQuestionEntity toSingle(dynamic data) {
+    return UserQuestionEntity.fromJson(
+      (data as List).first as Map<String, dynamic>,
+    );
+  }
+}

--- a/lib/features/user/domain/repositories/user_repository_interface.dart
+++ b/lib/features/user/domain/repositories/user_repository_interface.dart
@@ -1,0 +1,10 @@
+import 'package:fpdart/fpdart.dart';
+import 'package:mbti/features/common/domain/failures/failure.dart';
+import 'package:mbti/features/user/domain/entities/user_question_entity.dart';
+
+abstract interface class UserQuestionRepositoryInterface {
+  Future<Either<Failure, UserQuestionEntity>> getUserQuestion();
+
+  Future<Either<Failure, UserQuestionEntity>> createOrUpdateUserQuestion(
+      String questionId);
+}

--- a/lib/features/user/infrastructure/repositories/user_repository.dart
+++ b/lib/features/user/infrastructure/repositories/user_repository.dart
@@ -1,0 +1,53 @@
+import 'dart:developer';
+
+import 'package:fpdart/src/either.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:mbti/features/common/domain/failures/failure.dart';
+import 'package:mbti/features/user/domain/entities/user_question_entity.dart';
+import 'package:mbti/features/user/domain/entities/user_question_entity_converter.dart';
+import 'package:mbti/features/user/domain/repositories/user_repository_interface.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class UserQuestionRepository implements UserQuestionRepositoryInterface {
+  UserQuestionRepository(this.client, this.userId);
+
+  final SupabaseClient client;
+  final String userId;
+
+  static const String _table = 'mbti_user';
+
+  @override
+  Future<Either<Failure, UserQuestionEntity>> createOrUpdateUserQuestion(
+      String questionId) async {
+    log('UserQuestionRepository userid: $userId');
+    log('UserQuestionRepository questionId: $questionId');
+    try {
+      final data = await client
+          .from(_table)
+          .upsert({
+            'user_id': userId,
+            'currentQuestionId': questionId,
+            'result': '',
+          })
+          .select()
+          .withConverter(UserQuestionEntityConverter.toSingle);
+      return right(data);
+    } catch (e) {
+      return left(Failure.unprocessableEntity(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, UserQuestionEntity>> getUserQuestion() async {
+    try {
+      final data = await client
+          .from(_table)
+          .select()
+          .eq('user_id', userId)
+          .withConverter(UserQuestionEntityConverter.toSingle);
+      return right(data);
+    } catch (e) {
+      return left(Failure.unprocessableEntity(message: e.toString()));
+    }
+  }
+}

--- a/lib/features/user/user_question_provider.dart
+++ b/lib/features/user/user_question_provider.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:mbti/config/providers.dart';
+import 'package:mbti/features/auth/auth_provider.dart';
+import 'package:mbti/features/common/domain/failures/failure.dart';
+import 'package:mbti/features/user/application/user_question_update_constroller.dart';
+import 'package:mbti/features/user/domain/entities/user_question_entity.dart';
+import 'package:mbti/features/user/domain/repositories/user_repository_interface.dart';
+import 'package:mbti/features/user/infrastructure/repositories/user_repository.dart';
+
+final userQuestionRepositoryProvider =
+Provider<UserQuestionRepositoryInterface>((ref) {
+  final authRepository = ref.read(authRepositoryProvider);
+  final userId = authRepository.currentUser?.id ?? '';
+
+  return UserQuestionRepository(ref.watch(supabaseClientProvider), userId);
+});
+
+final userQuestionUpdateControllerProvider = StateNotifierProvider<
+    UserQuestionUpdateController,
+    AsyncValue<UserQuestionEntity>>((ref) {
+  final repo = ref.watch(userQuestionRepositoryProvider);
+  final response = UserQuestionUpdateController(repo);
+  return response;
+});
+
+final userQuestionProvider = FutureProvider<Either<Failure, UserQuestionEntity>>((ref) async {
+  final repo = ref.watch(userQuestionRepositoryProvider);
+  return await repo.getUserQuestion();
+});


### PR DESCRIPTION
### 구현
사용자가 질문지를 선택 할때마다 선택된 질문의 답변의 id를 mbti_user 테이블에 저장을 합니다.

질문지 화면에 진입하면 
mbti_user.currentQuestionId 를 읽어와 mbti_questions 테이블의 질문 목록에서 해당 질문의 index를 계산후 다음 질문 목록이 화면에 표시될수 있도록 합니다.

### 개선 사항
* mbti_questions 테이블에 order 필드가 필요하지 않을까? 질문의 순서를 변경할수 있도록
* 지금은 질문순서가 고정되어 있다고 가정하고 mbti_user.currentQuestionId 에 답변 질문 id를 저장 중인데, 좀더 정교하게 만들기 위해서는 user_answer 테이블을 참조하여 답변을 하지않은 필드만 추출해서 노출하는 방식도 고려해 볼만함.

### 이슈
* `QuestionsScreen.next`에서 userQuestionUpdateControllerProvider 참조시 생명주기에 따라 자동 해제 되도록 autoDispose를 연결 했는데 userQuestionUpdateControllerProvider를 참조하는 ref가 pager.item widget을 참조하다 페이징시 item widget이 pager에서 해제 되면 userQuestionUpdateControllerProvider 같이 해제되는 문제가 있음
  * 해결 방안 1 : userQuestionUpdateControllerProvider 의 autoDispose 제거
  * 해결 방안 2 : userQuestionUpdateControllerProvider의 ref를 상위 위젯인 pager를 참조.
  * 해결 방안 3 : ref.keepAlive 를 사용하여 userQuestionUpdateControllerProvider 동작을 유지하고, 동작이 완료되면 명시적으로 dispose 처리
 * QuestionsScreen._initialize() 가 위젯이 build 되는 동안 호출하는데 위젯안에 _pageIndexProvider를 watch 로 참조 중이고, _intialize() 함수 안에 _pageIndexProvider를 read로 참조하고 있음 
  기본적으로 riverPot은 위젯 빌되는 동안 read를 허용하지 않는다, 이는 위젯 빌드중에 프로바이더 값이 변경되면 이상동작이 발생할수 있어서이다.
    * 해결 방안 1 : _pageIndexProvider를 read 를 대신 watch를 사용
    * 해결 방안 2 : Future.delay...

